### PR TITLE
Fix j7/MallocPlus Crashes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,9 +124,6 @@ find_package(Boost ${BOOST_MIN_VER})
 #message("X11_LIBRARIES ${X11_LIBRARIES}")
 #message("X11_LIBS ${X11_LIBS}")
 
-# configure a header file to pass some of the CMake settings
-# to the source code
-configure_file ( "${PROJECT_SOURCE_DIR}/config.h.in" "${PROJECT_BINARY_DIR}/config.h")
  
 add_definitions(-DHAVE_CONFIG_H)
 
@@ -303,8 +300,10 @@ if (QUO_FOUND AND MPI_FOUND AND OPENMP_FOUND)
 
     add_executable(clamr_quo ${clamr_quo_SRCS})
 
-    set_target_properties(clamr_quo PROPERTIES COMPILE_DEFINITIONS "HAVE_MPI;HAVE_QUO;HAVE_J7")
-    # XXX add HAVE_J7 only at top-level
+    # these sets HAVE_J7 and HAVE_QUO in config.h
+    set(HAVE_J7 ON)
+    set(HAVE_QUO ON)
+    set_target_properties(clamr_quo PROPERTIES COMPILE_DEFINITIONS "HAVE_MPI")
 
     set(clamr_quo_link_flags "${OpenMP_CXX_FLAGS}")
     set_target_properties(clamr_quo PROPERTIES COMPILE_FLAGS ${OpenMP_C_FLAGS})
@@ -397,3 +396,8 @@ set (CMAKE_CHECK_COMMAND make -C ${CMAKE_SOURCE_DIR}/mesh/tests mesh_check &&
                          make -C ${CMAKE_SOURCE_DIR}/l7/tests   l7_check)
 
 add_custom_target(check COMMAND ${CMAKE_CHECK_COMMAND})
+
+# configure a header file to pass some of the CMake settings
+# to the source code
+# at bottom because we set things that change config above
+configure_file ( "${PROJECT_SOURCE_DIR}/config.h.in" "${PROJECT_BINARY_DIR}/config.h")

--- a/MallocPlus/CMakeLists.txt
+++ b/MallocPlus/CMakeLists.txt
@@ -23,8 +23,6 @@ target_link_libraries(dMallocPlus ezcl)
 if (Boost_FOUND AND MPI_FOUND)
     message(STATUS "Adding j7 support ot MallocPlus")
     target_link_libraries(dMallocPlus j7)
-    # XXX want to set HAVE_J7 at the top-level not all over the place
-    add_definitions(-DHAVE_J7)
 endif()
 install(TARGETS dMallocPlus DESTINATION lib)
 

--- a/MallocPlus/MallocPlus.cpp
+++ b/MallocPlus/MallocPlus.cpp
@@ -94,13 +94,6 @@ list<malloc_plus_memory_entry>::iterator it_save;
 
 #include "j7/j7.h"
 
-#if 0
-MallocPlus::MallocPlus(void)
-{
-    j7 = NULL;
-}
-#endif
-
 void
 MallocPlus::pinit(MPI_Comm smComm, std::size_t memPoolSize)
 {

--- a/MallocPlus/MallocPlus.h
+++ b/MallocPlus/MallocPlus.h
@@ -71,12 +71,6 @@ typedef float real;
 #define INDEX_ARRAY_MEMORY    0x00004
 #define LOAD_BALANCE_MEMORY   0x00008
 
-#if 1 // SKG for now don't really include J7 things.
-#ifdef HAVE_J7
-#undef HAVE_J7
-#endif
-#endif
-
 #ifdef HAVE_J7
 #include "mpi.h"
 // forward class declaration here because i don't want to include j7.h here
@@ -116,8 +110,6 @@ public:
    void pinit(MPI_Comm smComm, std::size_t memPoolSize);
    // parallel (typically MPI) finalization routine
    void pfini(void);
-   // default constructor
-   //MallocPlus(void);
 #endif
 
    void *memory_malloc(size_t nelem, size_t elsize, const char *name);

--- a/config.h.in
+++ b/config.h.in
@@ -43,3 +43,9 @@
 
 /* Define for large files, on AIX-style hosts. */
 #undef _LARGE_FILES
+
+/* Define if you have j7 support */
+#cmakedefine HAVE_J7
+
+/* Define if you have QUO support */
+#cmakedefine HAVE_QUO

--- a/l7/CMakeLists.txt
+++ b/l7/CMakeLists.txt
@@ -7,13 +7,6 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_MPI=1")
 #   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -vec-report3")
 #endif (CMAKE_C_COMPILER MATCHES "icc$")
 
-if(DEFINED ENV{QUO_HOME})
-   if(EXISTS "$ENV{QUO_HOME}/include/")
-      set (QUO_FOUND on)
-      include_directories($ENV{QUO_HOME}/include)
-   endif (EXISTS "$ENV{QUO_HOME}/include/")
-endif (DEFINED ENV{QUO_HOME})
-
 set(H_SRCS l7.h l7_assert.h l7p.h)
 
 set(C_SRCS
@@ -37,10 +30,6 @@ set(l7_LIB_SRCS ${C_SRCS} ${H_SRCS})
 
 add_library(l7 STATIC ${l7_LIB_SRCS})
 
-if (QUO_FOUND)
-set_target_properties(l7 PROPERTIES COMPILE_DEFINITIONS HAVE_QUO)
-endif(QUO_FOUND)
-
 set_target_properties(l7 PROPERTIES VERSION 2.0.0 SOVERSION 2)
 target_link_libraries(l7 ${MPI_LIBRARIES})
 install(TARGETS l7 DESTINATION lib)
@@ -51,11 +40,7 @@ set(dl7_LIB_SRCS ${C_SRCS} ${H_SRCS})
 add_library(dl7 STATIC ${l7_LIB_SRCS})
 
 set_target_properties(dl7 PROPERTIES VERSION 2.0.0 SOVERSION 2)
-if (QUO_FOUND)
-set_target_properties(dl7 PROPERTIES COMPILE_DEFINITIONS "HAVE_OPENCL;HAVE_QUO")
-else (QUO_FOUND)
 set_target_properties(dl7 PROPERTIES COMPILE_DEFINITIONS HAVE_OPENCL)
-endif (QUO_FOUND)
 target_link_libraries(dl7 ${MPI_LIBRARIES})
 target_link_libraries(dl7 ${OPENCL_LIBRARIES})
 add_dependencies(dl7 l7_kernel_source)

--- a/l7/l7_setup.c
+++ b/l7/l7_setup.c
@@ -403,9 +403,10 @@ int L7_Setup(
 #endif
 					/* Skip through all the rest on pe j. */
 					
-					while ( ( indices_needed[this_index] < 
-							     l7_id_db->starting_indices[j+1] ) &&
-							( this_index < num_indices_needed) )
+                    /* SKG - Update order to silence valgrind. Don't know if
+                     * this is okay... */
+					while ( ( this_index < num_indices_needed)  &&
+                            ( indices_needed[this_index] < l7_id_db->starting_indices[j+1] ) )
 						this_index++;
 					
 					/* Remember where we found the first one. */
@@ -505,8 +506,10 @@ int L7_Setup(
 		         
 		         this_index++;
 		         
-		         while ( ( indices_needed[this_index] < l7_id_db->starting_indices[j+1] ) &&
-		               ( num_indices_acctd_for < num_indices_needed ) ){
+                /* SKG - Update order to silence valgrind. Don't know if
+                 * this is okay... */
+		         while ( ( num_indices_acctd_for < num_indices_needed ) &&
+                        ( indices_needed[this_index] < l7_id_db->starting_indices[j+1] )) {
 		            /* Find the rest on pe j. */
 		            
 		            l7_id_db->recv_counts[i]++;


### PR DESCRIPTION
commit 9309343f9a5d9f242755dd5217d9c44ab921351d
Author: Samuel K. Gutierrez samuel@lanl.gov
Date:   Mon Nov 4 17:18:23 2013 -0700

```
Fix j7 in MallocPlus crashes.

This one was tricky. Don't really want to go into it. Basically it boils down to
different views of MallocPlus' structure. Thanks for your help @hjelmn.
```

commit 4013fa99af6d88035a299b866695ae01147f72c1
Author: Samuel K. Gutierrez samuel@lanl.gov
Date:   Mon Nov 4 15:02:46 2013 -0700

```
Silence valgrind warnings in l7.
```
