### PR TITLE
cmake: OpenGL needs glut

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,7 @@ endif (NOT GRAPHICS_TYPE)
 
 if (GRAPHICS_TYPE STREQUAL "OpenGL")
    find_package(OpenGL)
+   find_package(GLUT)
 endif (GRAPHICS_TYPE STREQUAL "OpenGL")
 
 # If autodetect does not work try setting MPEHOME or
@@ -282,12 +283,12 @@ endif (GRAPHICS_TYPE STREQUAL "MPE")
 #message("GRAPHICS_TYPE is ${GRAPHICS_TYPE}")
 #message("MPE_INCLUDE is ${MPE_INCLUDE_DIR}")
 
-if (OPENGL_FOUND)
+if (OPENGL_FOUND AND GLUT_FOUND)
    set (HAVE_GRAPHICS on)
    set (HAVE_OPENGL on)
    include_directories(${OPENGL_INCLUDE_DIR})
-   find_package(GLUT)
-endif (OPENGL_FOUND)
+   include_directories(${GLUT_INCLUDE_DIR})
+endif (OPENGL_FOUND AND GLUT_FOUND)
 
 #if(DEFINED ENV{QUO_HOME})
 #   if(EXISTS "$ENV{QUO_HOME}/include/")


### PR DESCRIPTION
OpenCL needs glut.h to be found.

Found as part of proxyapps/proxy-ci#2