### PR TITLE
Removed type mismatch in MallocPlus string comparison - Fixes #40

### DIFF
--- a/MallocPlus/MallocPlus.h
+++ b/MallocPlus/MallocPlus.h
@@ -100,9 +100,13 @@ struct malloc_plus_memory_entry {
 
 struct cmp_str
 {
-   bool operator()(char const *a, char const *b)
+   bool operator()(char const *a, char const *b) const
    {
       return strcmp(a, b) < 0;
+   }
+   bool operator()(const string &a, const string &b) const
+   {
+      return strcmp(&a[0], &b[0]) < 0;
    }
 };
 


### PR DESCRIPTION
Simple change: The arguments for the operator() in cmp_str were "char const *", 
but in MallocPlus.cpp in line 95 tries to use it with a std::string type.

Overloaded operator() so either argument set should work.

After change, compiles with gcc-8.1.0 and passes all tests on a Broadwell
Fixes #40 