### PR TITLE
added parens options to calc_finite_difference_regular_cells

### DIFF
--- a/state.cpp
+++ b/state.cpp
@@ -3807,10 +3807,24 @@ void State::calc_finite_difference_regular_cells(double deltaT)
 #pragma omp simd
          for(ii=2; ii<iimax-2; ii++){
             if (mask_reg_lev[ll][jj][ii] == 1) {
+#ifdef PRECISION_CHECK_WITH_PARENTHESES
+           //Basic parentheses
            states_new[ll][0][jj][ii] = U_fullstep(deltaT, dx, H_reg_lev[ll][jj][ii],
-           //H_reg_new[jj][ii] = U_fullstep(deltaT, dx, H_reg[jj][ii],
+                       Hxfluxplus[ll][jj][ii], Hxfluxminus[ll][jj][ii], Hyfluxplus[ll][jj][ii], Hyfluxminus[ll][jj][ii])
+                  + (- wminusx_H[ll][jj][ii] + wplusx_H[ll][jj][ii] - wminusy_H[ll][jj][ii] + wplusy_H[ll][jj][ii]);
+#else
+#ifdef PRECISION_CHECK_BEST_PARENTHESES
+           //Best parentheses version
+           states_new[ll][0][jj][ii] = U_fullstep(deltaT, dx, H_reg_lev[ll][jj][ii],
+                       Hxfluxplus[ll][jj][ii], Hxfluxminus[ll][jj][ii], Hyfluxplus[ll][jj][ii], Hyfluxminus[ll][jj][ii])
+                  + ((( -wminusx_H[ll][jj][ii] - wminusy_H[ll][jj][ii] ) + wplusy_H[ll][jj][ii] ) + wplusx_H[ll][jj][ii] );
+#else
+           //Original version with no parentheses
+           states_new[ll][0][jj][ii] = U_fullstep(deltaT, dx, H_reg_lev[ll][jj][ii],
                        Hxfluxplus[ll][jj][ii], Hxfluxminus[ll][jj][ii], Hyfluxplus[ll][jj][ii], Hyfluxminus[ll][jj][ii])
                   - wminusx_H[ll][jj][ii] + wplusx_H[ll][jj][ii] - wminusy_H[ll][jj][ii] + wplusy_H[ll][jj][ii];
+#endif
+#endif
 
            states_new[ll][1][jj][ii] = U_fullstep(deltaT, dx, U_reg_lev[ll][jj][ii],
            //U_reg_new[jj][ii] = U_fullstep(deltaT, dx, U_reg[jj][ii],


### PR DESCRIPTION
calc_finite_difference_regular_cells now has 3 options for parentheses (none, some, and best), just as like the options for the face-based method