### PR TITLE
Fix errors cell finite diff precision

### DIFF
--- a/state.cpp
+++ b/state.cpp
@@ -3807,13 +3807,13 @@ void State::calc_finite_difference_regular_cells(double deltaT)
 #pragma omp simd
          for(ii=2; ii<iimax-2; ii++){
             if (mask_reg_lev[ll][jj][ii] == 1) {
-#ifdef PRECISION_CHECK_WITH_PARENTHESES
+#ifdef PRECISION_CHECK_WITH_PARENTHESIS
            //Basic parentheses
            states_new[ll][0][jj][ii] = U_fullstep(deltaT, dx, H_reg_lev[ll][jj][ii],
                        Hxfluxplus[ll][jj][ii], Hxfluxminus[ll][jj][ii], Hyfluxplus[ll][jj][ii], Hyfluxminus[ll][jj][ii])
                   + (- wminusx_H[ll][jj][ii] + wplusx_H[ll][jj][ii] - wminusy_H[ll][jj][ii] + wplusy_H[ll][jj][ii]);
 #else
-#ifdef PRECISION_CHECK_BEST_PARENTHESES
+#ifdef PRECISION_CHECK_BEST_PARENTHESIS
            //Best parentheses version
            states_new[ll][0][jj][ii] = U_fullstep(deltaT, dx, H_reg_lev[ll][jj][ii],
                        Hxfluxplus[ll][jj][ii], Hxfluxminus[ll][jj][ii], Hyfluxplus[ll][jj][ii], Hyfluxminus[ll][jj][ii])

--- a/state.cpp
+++ b/state.cpp
@@ -1770,9 +1770,24 @@ void State::calc_finite_difference(double deltaT)
                       (Vtr - Vic))+wplusy_V)*HALF*HALF;
       }
 
+#ifdef PRECISION_CHECK_WITH_PARENTHESIS
+      //Basic parentheses
+      H_new[gix] = U_fullstep(deltaT, dxic, Hic,
+                       Hxfluxplus, Hxfluxminus, Hyfluxplus, Hyfluxminus)
+                  +( - wminusx_H + wplusx_H - wminusy_H + wplusy_H );
+#else
+#ifdef PRECISION_CHECK_BEST_PARENTHESIS
+      //Version with "best" parentheses
+      H_new[gix] = U_fullstep(deltaT, dxic, Hic,
+                       Hxfluxplus, Hxfluxminus, Hyfluxplus, Hyfluxminus)
+                   + (((-wminusx_H - wminusy_H) + wplusy_H) + wplusx_H);
+#else
+      //Original version - no parentheses
       H_new[gix] = U_fullstep(deltaT, dxic, Hic,
                        Hxfluxplus, Hxfluxminus, Hyfluxplus, Hyfluxminus)
                   - wminusx_H + wplusx_H - wminusy_H + wplusy_H;
+#endif
+#endif
       U_new[gix] = U_fullstep(deltaT, dxic, Uic,
                        Uxfluxplus, Uxfluxminus, Uyfluxplus, Uyfluxminus)
                   - wminusx_U + wplusx_U;


### PR DESCRIPTION
Adding parenthesis options to actual cell-based finite_diff
Also fixed a typo

Still TODO: switch "best" parentheses version to new "best" version