### PR TITLE
L7 testing and bug fixes

### DIFF
--- a/l7/l7_dev_setup.c
+++ b/l7/l7_dev_setup.c
@@ -408,9 +408,8 @@ int L7_Dev_Setup(
 #endif
 					/* Skip through all the rest on pe j. */
 					
-					while ( ( indices_needed[this_index] < 
-							     l7_id_db->starting_indices[j+1] ) &&
-							( this_index < num_indices_needed) )
+					while ( ( this_index < num_indices_needed) && 
+                                                ( indices_needed[this_index] < l7_id_db->starting_indices[j+1] ) )
 						this_index++;
 					
 					/* Remember where we found the first one. */
@@ -510,8 +509,8 @@ int L7_Dev_Setup(
 		         
 		         this_index++;
 		         
-		         while ( ( indices_needed[this_index] < l7_id_db->starting_indices[j+1] ) &&
-		               ( num_indices_acctd_for < num_indices_needed ) ){
+		         while ( ( num_indices_acctd_for < num_indices_needed ) && 
+                                 ( indices_needed[this_index] < l7_id_db->starting_indices[j+1] ) ) {
 		            /* Find the rest on pe j. */
 		            
 		            l7_id_db->recv_counts[i]++;
@@ -540,7 +539,7 @@ int L7_Dev_Setup(
 	 * those pes need. This is done use a reduction (MPI_Allreduce).
 	 */
 	
-	if (l7.sizeof_send_buffer < numpes * (int)sizeof(int)){
+	if (l7.sizeof_send_buffer < 2 * numpes * (int)sizeof(int)){
 	   if (l7.send_buffer)
 	      free(l7.send_buffer);
 	   

--- a/l7/l7_setup.c
+++ b/l7/l7_setup.c
@@ -413,7 +413,7 @@ int L7_Setup(
                     /* SKG - Update order to silence valgrind. Don't know if
                      * this is okay... */
 					while ( ( this_index < num_indices_needed)  &&
-                            ( indices_needed[this_index] < l7_id_db->starting_indices[j+1] ) )
+                                                ( indices_needed[this_index] < l7_id_db->starting_indices[j+1] ) )
 						this_index++;
 					
 					/* Remember where we found the first one. */
@@ -521,8 +521,8 @@ int L7_Setup(
 		         
                 /* SKG - Update order to silence valgrind. Don't know if
                  * this is okay... */
-		         while ( ( num_indices_acctd_for < num_indices_needed ) &&
-                        ( indices_needed[this_index] < l7_id_db->starting_indices[j+1] )) {
+                         while ( ( num_indices_acctd_for < num_indices_needed ) &&
+                                 ( indices_needed[this_index] < l7_id_db->starting_indices[j+1] )) {
 		            /* Find the rest on pe j. */
 		            
 		            l7_id_db->recv_counts[i]++;
@@ -551,7 +551,7 @@ int L7_Setup(
 	 * those pes need. This is done use a reduction (MPI_Allreduce).
 	 */
 	
-	if (l7.sizeof_send_buffer < numpes * (int)sizeof(int)){
+	if (l7.sizeof_send_buffer < 2 * numpes * (int)sizeof(int)){
 	   if (l7.send_buffer)
 	      free(l7.send_buffer);
 	   

--- a/l7/tests/update_test.c
+++ b/l7/tests/update_test.c
@@ -77,7 +77,7 @@ void update_test()
    partner_pe = (int *)malloc(num_partners * sizeof(int));
    
    offset = 0;
-   for (i=1; i<=num_partners_lo; i++){
+   for (i=num_partners_lo; i<=1; i--) {
       partner_pe[offset] = penum - i;
       offset++;
    }


### PR DESCRIPTION
1) Ensure update_test puts needed indices in ascending order. L7_Setup assumes this
(in how it constructs needed_global_indices), as does Dev_Setup, but neither directly
checks it. Adding this error check would be worthwhile for the future.
2) Make sure that enough space is allocated in Setup in the send_buffer for pi4_out.
3) Reverse the order of && checks in dev_setup to match setup and quiet a valgrind
warning.